### PR TITLE
Fix LoginProfiles.txt encoding to use Windows-1252

### DIFF
--- a/Services/ProfileService.cs
+++ b/Services/ProfileService.cs
@@ -418,7 +418,7 @@ public static class ProfileService
             return;
         }
 
-        var lines  = File.ReadAllLines(path).ToList();
+        var lines  = File.ReadAllLines(path, PrfEncoding).ToList();
         bool found = false;
 
         for (int i = 0; i < lines.Count; i++)
@@ -445,6 +445,6 @@ public static class ProfileService
             Logger.Log("APPLY", $"LoginProfiles.txt: inserted OBS profile {obsPrefix}_OBS into {path}");
         }
 
-        File.WriteAllLines(path, lines);
+        File.WriteAllLines(path, lines, PrfEncoding);
     }
 }


### PR DESCRIPTION
## Summary
- `PatchLoginProfiles` read/wrote `LoginProfiles.txt` with default UTF-8 encoding instead of Windows-1252, corrupting Swedish characters (ö, ä, å, etc.) in ATIS lines to `ï¿½`
- Pass `PrfEncoding` (Windows-1252) to both `File.ReadAllLines` and `File.WriteAllLines`, matching what `PatchPrf` already does correctly

Fixes #1

## Test plan
- [x] Fresh GNG pack install → configure OBS callsign → Apply → verify `LoginProfiles.txt` retains Swedish characters (Östgöta, Göteborg, Jönköping, etc.)
- [x] Open EuroScope connect dialog for a Swedish position (e.g. ESSP_APP) → NFO line 2 should show `Östgöta Approach`, not `ï¿½stgï¿½ta Approach`
- [x] Verify existing OBS profile patching still works (insert and update paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)